### PR TITLE
Refactor web streaming templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ yolov11_rpi5_project/
 │   ├── camera_stream.py           # Multithreaded camera handling
 │   ├── defines.py                 # All constants and magic numbers
 |   └── log.py                     # Centralized log file generator
+├── web/
+│   ├── templates/                 # Flask HTML templates
+│   └── static/                    # CSS, JS and images
 ├── comm/
 │   └── serial_comm.py             # Serial communication abstraction (RPI5 ⇆ ESP32-S3)
 ├── test_script/                   # To quickly test the hardware connection or if any error in hardware 

--- a/utils/web_stream.py
+++ b/utils/web_stream.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
 
-from flask import Flask, Response, render_template_string
+from flask import Flask, Response, render_template
 import cv2
 import threading
+from pathlib import Path
 
-app = Flask(__name__)
+BASE_DIR = Path(__file__).resolve().parent.parent
+app = Flask(
+    __name__,
+    template_folder=str(BASE_DIR / "web" / "templates"),
+    static_folder=str(BASE_DIR / "web" / "static"),
+)
 
 # Global frame buffer and lock
 _lock = threading.Lock()
@@ -37,53 +43,7 @@ def generate():
 @app.route('/')
 def index():
     """Render the main video stream page."""
-    html = """
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>Forklift Injury Prevention Device</title>
-        <style>
-            body {
-                background-color: #121212;
-                color: #f5f5f5;
-                font-family: 'Segoe UI', sans-serif;
-                text-align: center;
-                padding-top: 30px;
-            }
-            h1 {
-                font-size: 2em;
-                margin-bottom: 0.5em;
-                color: #ffca28;
-            }
-            p {
-                font-size: 1.1em;
-                margin-bottom: 1.5em;
-            }
-            .stream-container {
-                display: flex;
-                justify-content: center;
-                align-items: center;
-            }
-            .stream {
-                border: 3px solid #ffca28;
-                border-radius: 12px;
-                box-shadow: 0 0 20px rgba(255, 202, 40, 0.3);
-                width: 80vw;
-                max-width: 960px;
-            }
-        </style>
-    </head>
-    <body>
-        <h1>Forklift Injury Prevention Device Live Stream</h1>
-        <p>Streaming from Raspberry Pi</p>
-        <div class="stream-container">
-            <img class="stream" src="/video_feed" alt="Live Stream Unavailable">
-        </div>
-    </body>
-    </html>
-    """
-    return render_template_string(html)
+    return render_template("index.html")
 
 
 @app.route('/video_feed')

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -1,0 +1,32 @@
+body {
+    background-color: #121212;
+    color: #f5f5f5;
+    font-family: 'Segoe UI', sans-serif;
+    text-align: center;
+    padding-top: 30px;
+}
+
+h1 {
+    font-size: 2em;
+    margin-bottom: 0.5em;
+    color: #ffca28;
+}
+
+p {
+    font-size: 1.1em;
+    margin-bottom: 1.5em;
+}
+
+.stream-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.stream {
+    border: 3px solid #ffca28;
+    border-radius: 12px;
+    box-shadow: 0 0 20px rgba(255, 202, 40, 0.3);
+    width: 80vw;
+    max-width: 960px;
+}

--- a/web/static/js/scripts.js
+++ b/web/static/js/scripts.js
@@ -1,0 +1,2 @@
+// Placeholder JavaScript file
+console.log('Streaming page loaded');

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Forklift Injury Prevention Device</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+    <h1>Forklift Injury Prevention Device Live Stream</h1>
+    <p>Streaming from Raspberry Pi</p>
+    <div class="stream-container">
+        <img class="stream" src="/video_feed" alt="Live Stream Unavailable">
+    </div>
+
+    <script src="{{ url_for('static', filename='js/scripts.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move HTML out of `web_stream.py`
- add Flask template and static directories
- simplify Flask view code
- document new directories in README

## Testing
- `python3 -m compileall -q`

------
https://chatgpt.com/codex/tasks/task_e_686d25aa1cec832c8af8e017572d17a4