### PR TITLE
Fix bounding line scaling

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,7 +24,6 @@ from utils.defines import (
     DRAW_POINT_OFFSET,
     PHONE_COMMAND,
     BREACH_COMMAND,
-    FRAME_HEIGHT,
     PHONE_DETECT_FRAMES,
     CONFIDENCE_THRESHOLD_FACE,
     CONFIDENCE_THRESHOLD_PHONE
@@ -60,8 +59,9 @@ def main():
 
             bounds = get_bounds()
             if bounds is not None:
-                cv2.line(frame, (bounds[0], 0), (bounds[0], FRAME_HEIGHT), BOUND_LINE_COLOR, 2)
-                cv2.line(frame, (bounds[1], 0), (bounds[1], FRAME_HEIGHT), BOUND_LINE_COLOR, 2)
+                height = frame.shape[0]
+                cv2.line(frame, (bounds[0], 0), (bounds[0], height), BOUND_LINE_COLOR, 2)
+                cv2.line(frame, (bounds[1], 0), (bounds[1], height), BOUND_LINE_COLOR, 2)
 
             phone_present = False
             operator_count = 0

--- a/utils/web_stream.py
+++ b/utils/web_stream.py
@@ -88,7 +88,14 @@ def set_bounds():
         x2 = max(0.0, min(float(data['x2']), 1.0))
     except (TypeError, ValueError):
         return jsonify({'status': 'error'}), 400
-    _bounds = (int(x1 * FRAME_WIDTH), int(x2 * FRAME_WIDTH))
+    # Determine the width of the most recent frame if available. This ensures
+    # that the bounding line positions match the actual streamed frame even if
+    # the camera resolution differs from the configured FRAME_WIDTH constant.
+    with _lock:
+        frame_width = (_current_frame.shape[1]
+                       if _current_frame is not None else FRAME_WIDTH)
+
+    _bounds = (int(x1 * frame_width), int(x2 * frame_width))
     return jsonify({'status': 'ok'})
 
 


### PR DESCRIPTION
## Summary
- account for actual camera frame width when setting bounds
- draw bounding lines based on actual frame height

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686eba0bf45c832c82282bad672cfa2d