### PR TITLE
Add reset bounds API

### DIFF
--- a/utils/web_stream.py
+++ b/utils/web_stream.py
@@ -99,6 +99,14 @@ def set_bounds():
     return jsonify({'status': 'ok'})
 
 
+@app.route('/reset_bounds', methods=['POST'])
+def reset_bounds():
+    """Clear any existing bounding lines."""
+    global _bounds
+    _bounds = None
+    return jsonify({'status': 'ok'})
+
+
 def get_bounds():
     """Return the currently configured bounding lines."""
     return _bounds

--- a/web/static/js/scripts.js
+++ b/web/static/js/scripts.js
@@ -34,6 +34,7 @@ btn.addEventListener('click', () => {
     setting = true;
     points = [];
     message.textContent = 'Set the bounding lines by clicking on the camera feed';
+    fetch('/reset_bounds', { method: 'POST' });
     drawLines();
 });
 


### PR DESCRIPTION
## Summary
- clear existing bounding line coordinates via `/reset_bounds`
- trigger the reset when clicking **SET BOUNDS** in the web UI

## Testing
- `pytest -q` *(fails: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_686f61af69e0832ca3d285a60c7f2d66