### PR TITLE
Implement debouncing timers for phone and safe zone detection

### DIFF
--- a/utils/defines.py
+++ b/utils/defines.py
@@ -45,7 +45,12 @@ NOTICE_DURATION = 3
 
 # Detection settings
 DRAW_POINT_OFFSET = 5  # Pixels below the top line of the bbox
-PHONE_DETECT_FRAMES = 30
+
+# Number of frames to keep warnings active after the last detection.
+# Both phone detection and safe-zone breach detection use this value to
+# smooth out sporadic results.
+PHONE_SCAN_FRAMES = 30
+SAFE_ZONE_SCAN_FRAMES = 30
 
 # Serial command messages
 PHONE_COMMAND = "phone_detected"


### PR DESCRIPTION
## Summary
- add constants for phone and safe zone debounce timers
- use timer based debouncing for phone and safe zone detections

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_686fe01a902c832ca4f9d769a13e5c24