### PR TITLE
Update responsive UI layout

### DIFF
--- a/utils/defines.py
+++ b/utils/defines.py
@@ -41,7 +41,7 @@ UI_ALERT_COLOR = "#ff5252"
 UI_INFO_COLOR = "#42a5f5"
 
 # Notice display duration in seconds
-NOTICE_DURATION = 3
+NOTICE_DURATION = 1
 
 # Detection settings
 DRAW_POINT_OFFSET = 5  # Pixels below the top line of the bbox

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -7,9 +7,29 @@ body {
 }
 
 h1 {
+    position: relative;
     font-size: 2.4em;
-    margin-bottom: 0.5em;
+    margin: 0 0 10px 0;
     color: var(--primary-color);
+    padding: 0.3em 0;
+}
+
+h1::before,
+h1::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    width: 45%;
+    height: 2px;
+    background-color: var(--primary-color);
+}
+
+h1::before {
+    left: 0;
+}
+
+h1::after {
+    right: 0;
 }
 
 p {
@@ -25,6 +45,10 @@ p {
     align-items: center;
     justify-content: center;
     gap: 20px;
+    margin-top: 20px;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 /* Section containing the video feed */
@@ -80,13 +104,23 @@ button:hover {
     flex-direction: column;
     align-items: center;
     width: 100%;
-    max-width: 320px;
+    max-width: 380px;
+    background-color: #1a1a1a;
+    padding: 15px 20px;
+    border-radius: 12px;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
 }
 
 .message {
     margin-top: 10px;
-    height: 20px;
+    height: 24px;
     color: var(--primary-color);
+    font-size: 1.1em;
+}
+
+#setBoundsBtn {
+    padding: 14px 30px;
+    font-size: 1.1em;
 }
 
 /* Container for bounds button and its message */
@@ -164,9 +198,11 @@ button:hover {
     .page-container {
         flex-direction: row;
         align-items: flex-start;
+        justify-content: center;
+        gap: 40px;
     }
 
     .control-section {
-        margin-left: 20px;
+        margin-left: 0;
     }
 }

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -17,7 +17,24 @@ p {
     margin-bottom: 1.5em;
 }
 
-.stream-container {
+
+/* Layout container holding the stream and controls */
+.page-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+}
+
+/* Section containing the video feed */
+.stream-section {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+}
+
+/* Wrapper for the stream element */
+.stream-section {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -62,21 +79,48 @@ button:hover {
     background-color: #ffc107;
 }
 
+.control-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex: 0 0 320px;
+}
+
 .message {
     margin-top: 10px;
     height: 20px;
     color: var(--primary-color);
 }
 
-.indicator-container {
+.indicator-box {
+    background-color: #1e1e1e;
+    border-radius: 10px;
+    padding: 10px 15px;
     display: flex;
-    justify-content: center;
-    gap: 20px;
-    margin-top: 15px;
+    flex-direction: column;
+    gap: 8px;
+    align-items: center;
+    margin-bottom: 10px;
 }
 
 .indicator {
     color: var(--primary-color);
+}
+
+/* Form used to send sensor thresholds */
+.sensor-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+    width: 100%;
+    max-width: 260px;
+}
+
+.sensor-form input {
+    padding: 6px;
+    border: none;
+    border-radius: 4px;
 }
 
 .notice-container {
@@ -108,4 +152,16 @@ button:hover {
 
 .notice.critical {
     background-color: var(--alert-color);
+}
+
+/* Responsive layout adjustments */
+@media (min-width: 768px) {
+    .page-container {
+        flex-direction: row;
+        align-items: flex-start;
+    }
+
+    .control-section {
+        margin-left: 20px;
+    }
 }

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -7,7 +7,7 @@ body {
 }
 
 h1 {
-    font-size: 2em;
+    font-size: 2.4em;
     margin-bottom: 0.5em;
     color: var(--primary-color);
 }
@@ -23,6 +23,7 @@ p {
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
     gap: 20px;
 }
 
@@ -30,14 +31,14 @@ p {
 .stream-section {
     flex: 1;
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
 }
 
 /* Wrapper for the stream element */
-.stream-section {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+.stream-wrapper {
+    position: relative;
+    display: inline-block;
 }
 
 .stream {
@@ -52,11 +53,6 @@ p {
 .stream.alert {
     border-color: var(--alert-color);
     box-shadow: 0 0 80px rgba(255, 82, 82, 0.7);
-}
-
-.stream-wrapper {
-    position: relative;
-    display: inline-block;
 }
 
 #overlay {
@@ -83,13 +79,22 @@ button:hover {
     display: flex;
     flex-direction: column;
     align-items: center;
-    flex: 0 0 320px;
+    width: 100%;
+    max-width: 320px;
 }
 
 .message {
     margin-top: 10px;
     height: 20px;
     color: var(--primary-color);
+}
+
+/* Container for bounds button and its message */
+.bound-controls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 10px;
 }
 
 .indicator-box {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -14,24 +14,6 @@ h1 {
     padding: 0.3em 0;
 }
 
-h1::before,
-h1::after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    width: 45%;
-    height: 2px;
-    background-color: var(--primary-color);
-}
-
-h1::before {
-    left: 0;
-}
-
-h1::after {
-    right: 0;
-}
-
 p {
     font-size: 1.1em;
     margin-bottom: 1.5em;
@@ -70,7 +52,7 @@ p {
     border-radius: 12px;
     box-shadow: 0 0 40px rgba(255, 202, 40, 0.5);
     width: 80vw;
-    max-width: 960px;
+    max-width: 820px;
     transition: box-shadow 0.3s, border-color 0.3s;
 }
 
@@ -102,9 +84,9 @@ button:hover {
 .control-section {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    width: 100%;
-    max-width: 380px;
+    align-items: stretch; /* allow inner items to stretch */
+    flex: 0 1 480px; /* grow = 0, shrink = 1, basis = 480px */
+    max-width: 480px; /* NEW WIDTH */
     background-color: #1a1a1a;
     padding: 15px 20px;
     border-radius: 12px;

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -27,6 +27,11 @@
                 <canvas id="overlay"></canvas>
                 <div id="notices" class="notice-container"></div>
             </div>
+            <!-- Controls for setting the safe zone bounds -->
+            <div class="bound-controls">
+                <button id="setBoundsBtn">SET BOUNDS</button>
+                <div id="message" class="message"></div>
+            </div>
         </div>
 
         <!-- Right side controls and settings -->
@@ -40,8 +45,6 @@
                 <div id="countLabel" class="indicator">Number of Operator: 0</div>
             </div>
 
-            <button id="setBoundsBtn">SET BOUNDS</button>
-            <div id="message" class="message"></div>
 
             <!-- Placeholder sensor threshold inputs -->
             <div class="sensor-form">

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -3,7 +3,10 @@
 
 <head>
     <meta charset="UTF-8">
+    <!-- Make the page responsive on mobile devices -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Forklift Injury Prevention Device</title>
+    <!-- Pass dynamic colors from Flask -->
     <style>
         :root {
             --primary-color: {{ primary_color }};
@@ -16,21 +19,45 @@
 
 <body>
     <h1>Forklift Injury Prevention Device Live Stream</h1>
-    <p>Streaming from Raspberry Pi</p>
-    <div class="stream-container">
-        <div class="stream-wrapper">
-            <img id="stream" class="stream" src="/video_feed" alt="Live Stream Unavailable">
-            <canvas id="overlay"></canvas>
-            <div id="notices" class="notice-container"></div>
+    <div class="page-container">
+        <!-- Left side stream section -->
+        <div class="stream-section">
+            <div class="stream-wrapper">
+                <img id="stream" class="stream" src="/video_feed" alt="Live Stream Unavailable">
+                <canvas id="overlay"></canvas>
+                <div id="notices" class="notice-container"></div>
+            </div>
+        </div>
+
+        <!-- Right side controls and settings -->
+        <div class="control-section">
+            <p>Streaming from Raspberry Pi</p>
+
+            <!-- Indicator labels shown in a rounded container -->
+            <div class="indicator-box">
+                <div id="phoneLabel" class="indicator">Phone Detected: No</div>
+                <div id="operatorLabel" class="indicator">Operator: Not Present</div>
+                <div id="countLabel" class="indicator">Number of Operator: 0</div>
+            </div>
+
+            <button id="setBoundsBtn">SET BOUNDS</button>
+            <div id="message" class="message"></div>
+
+            <!-- Placeholder sensor threshold inputs -->
+            <div class="sensor-form">
+                <label for="topSensor">Top Sensor Threshold</label>
+                <input type="number" id="topSensor" />
+
+                <label for="leftSensor">Left Sensor Threshold</label>
+                <input type="number" id="leftSensor" />
+
+                <label for="rightSensor">Right Sensor Threshold</label>
+                <input type="number" id="rightSensor" />
+
+                <button type="button" id="sendSensorBtn">Send</button>
+            </div>
         </div>
     </div>
-    <div class="indicator-container">
-        <div id="phoneLabel" class="indicator">Phone Detected: No</div>
-        <div id="operatorLabel" class="indicator">Operator: Not Present</div>
-        <div id="countLabel" class="indicator">Number of Operator: 0</div>
-    </div>
-    <button id="setBoundsBtn">SET BOUNDS</button>
-    <div id="message" class="message"></div>
 
     <script src="{{ url_for('static', filename='js/scripts.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- redesign the live stream page with a left-side video feed and right-side controls
- add placeholder TOF sensor threshold inputs
- group status labels inside a rounded container
- make layout responsive with a flexbox design

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68702165b484832cb63cd515207eccc8